### PR TITLE
Use new Box component in imageResource demo

### DIFF
--- a/compose/src/main/java/de/jensklingenberg/jetpackcomposeplayground/ui/samples/other/LoadImage.kt
+++ b/compose/src/main/java/de/jensklingenberg/jetpackcomposeplayground/ui/samples/other/LoadImage.kt
@@ -1,20 +1,20 @@
 package de.jensklingenberg.jetpackcomposeplayground.ui.samples.other
 
-import android.media.Image
 import androidx.compose.Composable
-import androidx.ui.foundation.SimpleImage
+import androidx.ui.core.Modifier
+import androidx.ui.foundation.Box
+import androidx.ui.foundation.Image
 import androidx.ui.graphics.ImageAsset
+import androidx.ui.layout.*
 
-import androidx.ui.layout.Container
-import androidx.ui.layout.LayoutHeight
-import androidx.ui.layout.LayoutWidth
 import androidx.ui.res.imageResource
 import androidx.ui.unit.dp
 import de.jensklingenberg.jetpackcomposeplayground.ui.samples.R
 
 @Composable fun LoadImageResourceDemo(){
     val imRes: ImageAsset = imageResource(id = R.drawable.placeholder_1_1)
-   Container(modifier = LayoutHeight(50.dp)+LayoutWidth(50.dp)) {
-       SimpleImage(imRes)
-   }
+
+    Box(modifier = Modifier.preferredHeight(50.dp) + Modifier.preferredWidth(50.dp)) {
+        Image(imRes)
+    }
 }

--- a/mkdocs/general/loadimage.md
+++ b/mkdocs/general/loadimage.md
@@ -4,11 +4,10 @@ You can use **imageResource** to load an image from the resources
 
 ```kotlin
 @Composable fun LoadImageResourceDemo(){
-    val imRes: Image = imageResource(id = R.drawable.placeholder_1_1)
-  
-   Container(modifier = LayoutHeight(50.dp)+LayoutWidth(50.dp)) {
-       SimpleImage(imRes)
-   }
-}
+    val imRes: ImageAsset = imageResource(id = R.drawable.placeholder_1_1)
 
+    Box(modifier = Modifier.preferredHeight(50.dp) + Modifier.preferredWidth(50.dp)) {
+        Image(imRes)
+    }
+}
 ```


### PR DESCRIPTION
Replaces use of a few components that have been deprecated as of Compose 0.1.0-dev08.

`Container` to `Box`
`SimpleImage` to `Image`