### PR TITLE
Update contributing to include info on GH Actions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,28 +5,30 @@ If you want to improve Compose, join the Kotlin Slack and the **#compose** chann
 
 ## to this project
 This project is using [MkDocs](https://www.mkdocs.org/) and the [MkDocs-Material Theme](https://squidfunk.github.io/mkdocs-material/) to generate the pages for Github.
-The markdown files are located in [/mkdocs](https://github.com/Foso/Jetpack-Compose-Playground/tree/master/mkdocs).
-The generated files for the github page are in [/docs](https://github.com/Foso/Jetpack-Compose-Playground/tree/master/docs). Do not make changes in this folder, they will be overriden
+The markdown files are located in [/docs](https://github.com/Foso/Jetpack-Compose-Playground/tree/master/docs).
+The generated files for the GitHub page are in [/site](https://github.com/Foso/Jetpack-Compose-Playground/tree/master/.github/workflows/gh-pages.yml#L32). Do not make changes in this folder, they will be overridden.
 
 * Install plugins
 
-```kotlin
-pip3 install mkdocs-minify-plugin
-pip3 install mkdocs-git-revision-date-localized-plugin
-```
+    ```
+    pip3 install mkdocs-minify-plugin
+    pip3 install mkdocs-git-revision-date-localized-plugin
+    ```
 
 * Run docs locally
 
-To start the mkdocs server locally, run **mkdocs serve** in a terminal in the project folder.
+    To start the mkdocs server locally, run **mkdocs serve** in a terminal in the project folder.
 
 
 * Add/Change docs
 
-The docs are written in markdown files which are all in [/mkdocs](https://github.com/Foso/Jetpack-Compose-Playground/tree/master/mkdocs). To change the navigation sidebar, you need to edit the **mkdocs.yml**.
+    The docs are written in markdown files which are all in [/docs](https://github.com/Foso/Jetpack-Compose-Playground/tree/master/docs). To change the navigation sidebar, you need to edit the **mkdocs.yml**.
 
 * Build the docs
 
-When you run **mkdocs build** in a terminal in the project folder, the html files be generated to [/docs](https://github.com/Foso/Jetpack-Compose-Playground/tree/master/docs)
+    When you run **mkdocs build** in a terminal in the project folder, the html files be generated to [/site](https://github.com/Foso/Jetpack-Compose-Playground/tree/master/docs).
+
+    When deployed, these files are built for GitHub Pages using a [workflow](https://github.com/Foso/Jetpack-Compose-Playground/actions).
 
 
 Feel free to change/add files and send a pull request.

--- a/docs/cookbook/loadimage.md
+++ b/docs/cookbook/loadimage.md
@@ -34,5 +34,7 @@ fun ImageVectorResourceDemo() {
 
 
 <hr>
+
 ## See also:
+
 * [How to load an image from the resource folder?](https://github.com/vinaygaba/Learn-Jetpack-Compose-By-Example/blob/master/app/src/main/java/com/example/jetpackcompose/image/ImageActivity.kt#L87)


### PR DESCRIPTION
* Fixes broken Markdown formatting in loadimage.md guide
* Fixes broken /mkdocs links in contributing guide and indentation

## Before
![Screenshot 2020-10-18 125036](https://user-images.githubusercontent.com/9521010/96374400-8a409700-1140-11eb-8b35-7bec67e49e0f.png)


## After
![Screenshot 2020-10-18 124845](https://user-images.githubusercontent.com/9521010/96374381-68dfab00-1140-11eb-89ab-587b80f10461.png)

