### PR TITLE
Add composables.co in compose_projects.md

### DIFF
--- a/docs/compose_projects.md
+++ b/docs/compose_projects.md
@@ -44,6 +44,7 @@ A list of projects that are related to Jetpack Compose. If you want to add an en
 | [Compose.Academy](https://compose.academy/)  		    |  |
 | [Jetpackcompose.app](https://Jetpackcompose.app)  		    |  |
 | [Jetpack Compose 中文文档](https://docs.compose.net.cn/) |
+| [Composables.co](https://www.composables.co) | Articles & resources for Jetpack Compose |
 
 # Compose for Web
 


### PR DESCRIPTION
This PR adds [composables.co](https://composables.co) in the list of useful websites about Jetpack Compose.

Composables.co  is where I release an article about jetpack compose per week. the articles are often features in newsletters such as Android Weekly, Kotlin Weekly and jetc.dev. Some articles:
- [Everything you need to know about State](https://www.composables.co/blog/state)
- [Everything you need to know about Side Effects](https://www.composables.co/blog/side-effects)
- [How to use Bottom Sheets with Material 2 and 3](https://www.composables.co/blog/bottomsheet)

The site also contains useful tools and links for Android Developers such as:
- [Android Distribution Chart](https://www.composables.co/tools/distribution-chart)


PS: Also opened https://github.com/Foso/Jetpack-Compose-Playground/pull/146. Could not merge the two changes as I did this change from the web editor.