### PR TITLE
fix ui-test library reference in ui testing set up

### DIFF
--- a/docs/general/testing.md
+++ b/docs/general/testing.md
@@ -4,7 +4,7 @@
 Add the Compose testing library to your dependencies in build.gradle
 
 ```kotlin
-androidTestImplementation("androidx.ui:ui-test:$compose_version")
+androidTestImplementation("androidx.compose.ui:ui-test:$compose_version")
 debugImplementation("androidx.compose.ui:ui-test-manifest:$compose_version")
 ```
 


### PR DESCRIPTION
Add missing `compose` part of the `androidx.compose.ui:ui-test` library reference in the set up ui tests documentation.