### PR TITLE
Include Jetpack Compose components link

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -43,6 +43,7 @@
 | [Release Notes](https://developer.android.com/jetpack/androidx/releases/ui)  		    | |
 | [Compse UI Docu](https://developer.android.com/reference/kotlin/androidx/ui/packages)  		    | |
 | [Jetpack Compose Twitter Bot](https://twitter.com/ComposeBot)  		    | |
-| [Jetpack Compose 中文文档](https://docs.compose.net.cn/) |
+| [Jetpack Compose 中文文档](https://docs.compose.net.cn/) | |
+| [Jetpack Compose Components](https://www.composables.com/components) | |
 
 Feel free to contribute!


### PR DESCRIPTION
Included the [Jetpack Compose Components list](https://composables.com/components) on resources.

The page got a lot of attention from the community so I figured it's worth including here.