### PR TITLE
Update AlertDialog pages to use "TextButton"s instead of regular Buttons

### DIFF
--- a/app/src/main/java/de/jensklingenberg/jetpackcomposeplayground/mysamples/github/material/alertdialog/AlertDialogSample.kt
+++ b/app/src/main/java/de/jensklingenberg/jetpackcomposeplayground/mysamples/github/material/alertdialog/AlertDialogSample.kt
@@ -36,8 +36,7 @@ fun AlertDialogSample() {
                         Text("Here is a text ")
                     },
                     confirmButton = {
-                        Button(
-
+                        TextButton(
                             onClick = {
                                 openDialog.value = false
                             }) {
@@ -45,8 +44,7 @@ fun AlertDialogSample() {
                         }
                     },
                     dismissButton = {
-                        Button(
-
+                        TextButton(
                             onClick = {
                                 openDialog.value = false
                             }) {

--- a/docs/material/alertdialog.md
+++ b/docs/material/alertdialog.md
@@ -39,8 +39,7 @@ fun AlertDialogSample() {
                         Text("Here is a text ")
                     },
                     confirmButton = {
-                        Button(
-
+                        TextButton(
                             onClick = {
                                 openDialog.value = false
                             }) {
@@ -48,8 +47,7 @@ fun AlertDialogSample() {
                         }
                     },
                     dismissButton = {
-                        Button(
-
+                        TextButton(
                             onClick = {
                                 openDialog.value = false
                             }) {


### PR DESCRIPTION
According to the Material documentation[1] and the documentation in `AlertDialog`[2], the correct Button style to use are `TextButton`s and not regular (colored) `Button`s.


[1]: https://m3.material.io/components/dialogs/overview
[2]: https://developer.android.com/jetpack/compose/components/dialog

Note: This PR does not update the screenshots used on the AlertDialog page.
