### PR TITLE
docs: fix typo Compse to Compose in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Look in the [repo](https://github.com/Foso/Jetpack-Compose-Playground/tree/maste
 | [Jetpack Compose Tutorial ](https://developer.android.com/jetpack/compose)  		    | |
 | [AndroidX Git Compose](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-master-dev/compose/)  		    | |
 | [Release Notes](https://developer.android.com/jetpack/androidx/releases/ui)  		    | |
-| [Compse UI Docu](https://developer.android.com/reference/kotlin/androidx/ui/packages)  		    | |
+| [Compose UI Docu](https://developer.android.com/reference/kotlin/androidx/ui/packages)  		    | |
 | [Video - Jetpack compose - MVVM State management in a simple way](https://youtu.be/KTvP27FpXd0)  		    | |
 | [Jetpack Compose Twitter Bot](https://twitter.com/ComposeBot)  		    | |
 | [SSComposeCookBook](https://github.com/SimformSolutionsPvtLtd/SSComposeCookBook/)  		    | |

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,4 @@
+#Mon Mar 30 17:44:29 IST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip


### PR DESCRIPTION
Fixed a typo in the Other Links table - "Compse UI Docu" corrected to "Compose UI Docu"
